### PR TITLE
Implement Transition Effect for Toasters Progress Bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,5 +55,6 @@
         </p>
         <div class="progress-bar" id="error-bottom-border"></div>
     </div>
+    <script src="./toaster.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -47,12 +47,13 @@ body {
 }
 
 .progress-bar {
-  width: 35%;
+  width: 0%;
   height: 0.3em;
   position: absolute;
   bottom: 0;
   left: 0.04em;
   border-bottom-left-radius: 0.3rem;
+  border-bottom-right-radius: 0.3rem;
 }
 
 #success-bottom-border {

--- a/style.css
+++ b/style.css
@@ -12,7 +12,7 @@ body {
 .toaster-container {
   background-color: white;
   border-radius: 0.5rem;
-  width: 20%;
+  width: 20rem;
   display: flex;
   padding: 0px 10px;
   justify-items: center;

--- a/toaster.js
+++ b/toaster.js
@@ -1,0 +1,21 @@
+const toasterContainer = document.getElementsByClassName("toaster-container");
+const progressBar = document.getElementsByClassName("progress-bar");
+
+const progressBarArray = Array.from(progressBar);
+const toasterContainerArray = Array.from(toasterContainer);
+
+function setTransition() {
+  progressBarArray.map((progressDiv) => {
+    setTimeout(() => {
+      progressDiv.style.width = "100%";
+      progressDiv.style.transition = "width 8s ease-in-out";
+      progressDiv.addEventListener("transitionend", () => {
+        toasterContainerArray.forEach(
+          (toast) => (toast.style.display = "none")
+        );
+      });
+    }, 1000);
+  });
+}
+
+setTransition();


### PR DESCRIPTION
This pull request adds a transition effect to the toast notifications. When a toaster is triggered, the progress bar smoothly fills over 8 seconds, and after the transition completes, the toaster containers are set to 'display: none', ensuring they are hidden from view. 

https://github.com/ry7an/ry7an-Toaster/assets/66907264/47ec51c8-48a3-423e-907a-2b1de6eb904a

